### PR TITLE
feat: Add agnostic Iot Edge Deployment action

### DIFF
--- a/.github/actions/iot-edge-deploy-manifest/action.yml
+++ b/.github/actions/iot-edge-deploy-manifest/action.yml
@@ -77,7 +77,7 @@ runs:
         deployment-name: ${{ steps.deployment-details.outputs.deployment-name }}
         layered: true
         iot-hub-name: ${{ steps.deployment-details.outputs.iot-hub-name }}
-        priority: 3
+        priority: ${{ inputs.priority }}
         target-condition: ${{ inputs.target_condition }}
     - name: "Deploy skipped due to existing tag ${{ inputs.sem_ver  }}"
       if: ${{ inputs.image == null }}

--- a/.github/actions/iot-edge-deploy-manifest/action.yml
+++ b/.github/actions/iot-edge-deploy-manifest/action.yml
@@ -1,10 +1,10 @@
-#### 
+####
 # Requires a file named edge-deployment.json in the repo using the template.
 # See sample manifest: DeployEdgeManifest.json
 #
 ####
 name: IotEdgeManifestDeploy
-description: 'Deploy IoT Edge manifest'
+description: "Deploy IoT Edge manifest"
 inputs:
   azure_rbac_credentials:
     required: true
@@ -30,11 +30,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: 'Login via Azure CLI'
+    - name: "Login via Azure CLI"
       uses: azure/login@v1
       with:
         creds: ${{ inputs.azure_rbac_credentials }}
-    - name: 'Set image url in manifest file'
+    - name: "Set image url in manifest file"
       uses: cschleiden/replace-tokens@v1
       with:
         files: '["edge-deployment.json"]'
@@ -43,10 +43,8 @@ runs:
     - name: Show edge deployment
       shell: bash
       run: |
-          cat edge-deployment.json
-    - name: 'Deploy edge manifest to IoT Hub'
-      if: ${{ inputs.image != null }}
-      shell: bash
+        cat edge-deployment.json
+    - id: deployment-details
       run: |
         branch_name=${{ github.ref }}
         echo "Branch: $branch_name"
@@ -65,25 +63,24 @@ runs:
             env="dev"
         fi 
         iot_hub_name=$(az iot hub list --query "[?starts_with(name,'iot-$env-evoy-')].name" --output tsv)
-        echo "Deploying to IoT Hub: '$iot_hub_name'"
-        existingDeployment=$(az iot edge deployment list --hub-name $iot_hub_name --query "reverse(sort_by([?starts_with(id,'$deployment_name')].{id:id, created:createdTimeUtc}, &created))[0].id" --output tsv)
-        
         deployment_name="$deployment_name-$build_id"
-        echo "Creating deployment: '$deployment_name'"
-        echo 'az iot edge deployment create -n $iot_hub_name -d "$deployment_name" --content edge-deployment.json --target-condition "${{ inputs.target_condition }}" --layered --priority ${{ inputs.priority }}'
-        az iot edge deployment create -n $iot_hub_name -d "$deployment_name" --content edge-deployment.json --target-condition "${{ inputs.target_condition }}" --layered --priority ${{ inputs.priority }}
-        
-        if [ ! -z "$existingDeployment" ]
-        then
-            echo "Deleting previous deployment: '$existingDeployment'"
-            az iot edge deployment delete -n $iot_hub_name -d "$existingDeployment"
-        fi
-    - name: 'Deploy skipped due to existing tag ${{ inputs.sem_ver  }}'
+
+        echo "iot-hub-name=$iot_hub_name" >> "$GITHUB_OUTPUT"
+        echo "deployment-name="$deployment_name-$build_id" >> "$GITHUB_OUTPUT"
+      shell: bash
+    - name: "Deploy edge manifest to IoT Hub"
+      if: ${{ inputs.image != null }}
+      uses: "./.github/actions/iot-edge-deploy"
+      with:
+        azure-credentials: ${{ inputs.azure_rbac_credentials }}
+        content: edge-deployment.json
+        deployment-name: ${{ steps.deployment-details.outputs.deployment-name }}
+        layered: true
+        iot-hub-name: ${{ steps.deployment-details.outputs.iot-hub-name }}
+        priority: 3
+        target-condition: ${{ inputs.target_condition }}
+    - name: "Deploy skipped due to existing tag ${{ inputs.sem_ver  }}"
       if: ${{ inputs.image == null }}
       shell: bash
       run: |
         echo "Deploy skipped due to existing tag ${{ inputs.sem_ver  }}"
-    - name: Azure logout
-      shell: bash
-      run: |
-        az logout

--- a/.github/actions/iot-edge-deploy/README.md
+++ b/.github/actions/iot-edge-deploy/README.md
@@ -1,0 +1,29 @@
+# GitHub Action for creating an IOT Edge Deployment
+
+The action creates an IoT Edge deployment in a target IoT Hub.
+
+:exclamation: NB! If there is an existing deployment in the IoT Hub with an equal deployment name, then the existing deployment will be deleted to avoid duplicates.
+
+## Usage
+
+```yaml
+- uses: evoy-as/.github/.github/actions/iot-edge-deploy@main
+  with:
+    # Credentials used to authenticate Azure CLI.
+    azure-credentials: ""
+    # IoT Edge deployment content. Provide file path or raw json.
+    # NOTE: The raw json must start and end with an escaped double quote, e.g '"{"modulesContent":{...}}"'.
+    content: ./modules_content.json
+    # Wether or not this deployment should be layered. Defaults to false.
+    layered: true
+    # The name of the IoT Hub that the deployment should be created for.
+    iot-hub-name: ""
+    # The name used for the deployment.
+    deployment-name: ""
+    # Weight of deployment in case of competing rules (highest wins). Defaults to 0.
+    priority: 3
+    # Target condition in which an edge deployment applies to. Deployments with no target condition will target no device.
+    target-condition: ""
+```
+
+Read more about the different parameters at [az iot edge deployment create](https://learn.microsoft.com/en-us/cli/azure/iot/edge/deployment?view=azure-cli-latest#az-iot-edge-deployment-create)

--- a/.github/actions/iot-edge-deploy/README.md
+++ b/.github/actions/iot-edge-deploy/README.md
@@ -2,7 +2,7 @@
 
 The action creates an IoT Edge deployment in a target IoT Hub.
 
-:exclamation: NB! If there is an existing deployment in the IoT Hub with an equal deployment name, then the existing deployment will be deleted to avoid duplicates.
+:exclamation: NOTE: If there is an existing deployment in the IoT Hub with an equal deployment name, then the existing deployment will be deleted to avoid duplicates. TODO: add a new parameter (type boolean) to be able to turn this functionality on or off (default to off).
 
 ## Usage
 

--- a/.github/actions/iot-edge-deploy/action.yml
+++ b/.github/actions/iot-edge-deploy/action.yml
@@ -1,0 +1,70 @@
+name: Create an IoT Edge deployment in a target IoT Hub
+
+inputs:
+  azure-credentials:
+    description: "Credentials used to authenticate Azure CLI."
+    required: true
+    type: string
+  content:
+    description: "The content of the manifest. Can be a file name or a string containing JSON"
+    required: true
+    type: string
+  deployment-name:
+    description: "The name used for the deployment."
+    required: true
+    type: string
+  layered:
+    description: "Wether or not this deployment should be layered. Defaults to false."
+    default: false
+    required: false
+    type: boolean
+  iot-hub-name:
+    description: "The name of the IoT Hub that the deployment should be created for."
+    required: true
+    type: string
+  priority:
+    default: 0
+    description: "The priority of the deployment."
+    required: false
+    type: number
+  target-condition:
+    default: ""
+    description: "The target condition of the deployment."
+    required: false
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Login via Azure CLI"
+      uses: azure/login@v1
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: "Deploy edge manifest to IoT Hub"
+      run: |
+        echo "Install azure-iot extension"
+        az config set extension.use_dynamic_install=yes_without_prompt
+        az extension add --name azure-iot
+
+        echo "Deploying to IoT Hub: '$iot_hub_name'"
+        existingDeployment=$(az iot edge deployment list --hub-name $iot_hub_name --query "reverse(sort_by([?id=='$deployment_name'].{id:id, created:createdTimeUtc}, &created))[0].id" --output tsv)
+
+        echo "Creating deployment: '$deployment_name'"
+        az iot edge deployment create -n $iot_hub_name -d "$deployment_name" --content ${{ inputs.content }} --target-condition "${{ inputs.target-condition }}" --layered ${{ inputs.layered }} --priority ${{ inputs.priority }}
+
+        if [ ! -z "$existingDeployment" ]
+        then
+            echo "Deleting previous deployment: '$existingDeployment'"
+            az iot edge deployment delete -n $iot_hub_name -d "$existingDeployment"
+        fi
+      shell: bash
+      env:
+        deployment_name: ${{ inputs.deployment-name }}
+        iot_hub_name: ${{ inputs.iot-hub-name }}
+
+    - name: "Logout of Azure CLI"
+      run: |
+        az logout
+        az cache purge
+        az account clear


### PR DESCRIPTION
The existing `iot-edge-deploy-manifest` is quick to configure, but in turn it does some assumptions in regards to the environment it is executed on, e.g `iot-hub-name` and `deployment-name` is based upon branch name.

I would like to suggest an alternative action that is more agnostic/"dumber", that would require these values to be set as input parameters. The action has **mostly** the same parameters and requirements as [az iot edge deployment](https://learn.microsoft.com/en-us/cli/azure/iot/edge/deployment?view=azure-cli-latest#az-iot-edge-deployment-create). This would require more configuration, but in turn could be easier to use across different environment setups.