### PR TITLE
fix: `gitversion-tag` and `iot-edge-deploy-manifest` errors

### DIFF
--- a/.github/actions/gitversion-tag/action.yml
+++ b/.github/actions/gitversion-tag/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "Tag exists: ${{ steps.checkTag.outputs.exists }}. Skipping tagging."
     - name: Tag version
       if: ${{ github.ref == 'refs/heads/main' && steps.checkTag.outputs.exists == 'false' }}
-      uses: "./.github/actions/git-tag"
+      uses: "evoy-as/.github/.github/actions/git-tag@main"
       with:
         annotation: "Tagged version ${{ steps.gitversion.outputs.semVer }}"
         tag: "${{ steps.gitversion.outputs.semVer }}"

--- a/.github/actions/iot-edge-deploy-manifest/action.yml
+++ b/.github/actions/iot-edge-deploy-manifest/action.yml
@@ -70,7 +70,7 @@ runs:
       shell: bash
     - name: "Deploy edge manifest to IoT Hub"
       if: ${{ inputs.image != null }}
-      uses: "./.github/actions/iot-edge-deploy"
+      uses: "evoy-as/.github/.github/actions/iot-edge-deploy@main"
       with:
         azure-credentials: ${{ inputs.azure_rbac_credentials }}
         content: edge-deployment.json


### PR DESCRIPTION
Replaced references to local actions in `gitversion-tag` and `iot-edge-deploy-manifest` with reference to their main branch.