### PR TITLE
feat: Add support for authenticating Azure CLI in `azkv-install`

### DIFF
--- a/.github/actions/azkv-install/action.yml
+++ b/.github/actions/azkv-install/action.yml
@@ -1,8 +1,12 @@
 name: Install the azkv CLI to the current working directory
 
 inputs:
+  azure-credentials:
+    description: "The Azure RBAC credentials to use for authenticating Azure CLI"
+    required: false
+    type: string
   private-key:
-    description: "The GitHub App private key to use for authentication"
+    description: "The GitHub App private key to use for authentication to download azkv"
     required: true
     type: string
 
@@ -22,3 +26,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+    - name: "Authenticate Azure CLI"
+      if: ${{ inputs.azure-credentials != '' }}
+      uses: azure/login@v2
+      with:
+        creds: ${{ inputs.azure-credentials }}


### PR DESCRIPTION
Added new optional input parameter `azure-credentials` to action `azkv-install`. If the credentials are provided, then it will be used to authenticate Azure CLI.